### PR TITLE
fix: mobile-responsive Agent Guide, Client API, and Factories pages

### DIFF
--- a/demo/src/sections/AgentGuideSection.tsx
+++ b/demo/src/sections/AgentGuideSection.tsx
@@ -21,23 +21,25 @@ export function AgentGuideSection() {
 
       {/* Rules */}
       <h2 className="text-xl font-bold text-gray-900 mb-4">Rules & Gotchas</h2>
-      <div className="flex gap-6 mb-14">
+      <div className="flex flex-col md:flex-row gap-4 md:gap-6 mb-8 sm:mb-14">
         {/* Rule list */}
-        <div className="w-64 flex-shrink-0 space-y-1">
-          {AGENT_RULES.map((rule, i) => (
-            <button
-              key={i}
-              onClick={() => setActiveRule(rule)}
-              className={`w-full text-left px-3 py-2.5 rounded-xl text-sm transition-all ${
-                activeRule.title === rule.title
-                  ? 'bg-primary-50 text-primary-700 font-semibold border border-primary-200'
-                  : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
-              }`}
-            >
-              <span className="text-gray-300 text-xs font-mono mr-2">{String(i + 1).padStart(2, '0')}</span>
-              {rule.title}
-            </button>
-          ))}
+        <div className="md:w-64 flex-shrink-0">
+          <div className="flex md:flex-col gap-1 overflow-x-auto md:overflow-x-visible pb-2 md:pb-0">
+            {AGENT_RULES.map((rule, i) => (
+              <button
+                key={i}
+                onClick={() => setActiveRule(rule)}
+                className={`text-left px-3 py-2.5 rounded-xl text-sm transition-all whitespace-nowrap md:whitespace-normal md:w-full ${
+                  activeRule.title === rule.title
+                    ? 'bg-primary-50 text-primary-700 font-semibold border border-primary-200'
+                    : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
+                }`}
+              >
+                <span className="text-gray-300 text-xs font-mono mr-2">{String(i + 1).padStart(2, '0')}</span>
+                {rule.title}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Rule detail */}
@@ -71,8 +73,8 @@ export function AgentGuideSection() {
 
       {/* Wire format quick reference */}
       <h2 className="text-xl font-bold text-gray-900 mb-1">Wire Format Quick Reference</h2>
-      <p className="text-sm text-gray-400 mb-5">Key fields in every v3 uischema element and what they mean</p>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-14">
+      <p className="text-sm text-gray-400 mb-4 sm:mb-5">Key fields in every v3 uischema element and what they mean</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-8 sm:mb-14">
         {WIRE_FORMAT_NOTES.map((note) => (
           <div key={note.field} className="bg-white border border-gray-100 rounded-xl p-4">
             <p className="font-mono text-sm text-primary-700 font-semibold mb-1">{note.field}</p>

--- a/demo/src/sections/ClientApiSection.tsx
+++ b/demo/src/sections/ClientApiSection.tsx
@@ -34,42 +34,44 @@ export function ClientApiSection() {
         </p>
       </div>
 
-      <div className="flex gap-6">
+      <div className="flex flex-col md:flex-row gap-4 md:gap-6">
         {/* Left: method list */}
-        <div className="w-60 flex-shrink-0">
-          {groups.map(({ group, methods }) => (
-            <div key={group} className="mb-5">
-              <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2 px-1">
-                {GROUP_ICONS[group]} {GROUP_LABELS[group]}
-              </p>
-              <div className="space-y-0.5">
-                {methods.map((m) => (
-                  <button
-                    key={m.name}
-                    onClick={() => setSelected(m)}
-                    className={`w-full text-left px-3 py-2 rounded-xl text-xs transition-all flex items-center gap-2 ${
-                      selected.name === m.name
-                        ? 'bg-primary-50 text-primary-700 font-semibold'
-                        : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
-                    }`}
-                  >
-                    <span className="font-mono truncate">{m.name}</span>
-                    {m.alpha && (
-                      <span className="flex-shrink-0 text-[9px] font-bold uppercase tracking-wider text-amber-600 bg-amber-50 border border-amber-200 rounded px-1 py-px">
-                        alpha
-                      </span>
-                    )}
-                  </button>
-                ))}
+        <div className="md:w-60 flex-shrink-0">
+          <div className="flex md:flex-col gap-1 overflow-x-auto md:overflow-x-visible pb-2 md:pb-0">
+            {groups.map(({ group, methods }) => (
+              <div key={group} className="mb-3 md:mb-5 flex-shrink-0">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2 px-1 whitespace-nowrap">
+                  {GROUP_ICONS[group]} {GROUP_LABELS[group]}
+                </p>
+                <div className="flex md:flex-col gap-0.5">
+                  {methods.map((m) => (
+                    <button
+                      key={m.name}
+                      onClick={() => setSelected(m)}
+                      className={`text-left px-3 py-2 rounded-xl text-xs transition-all flex items-center gap-2 whitespace-nowrap md:whitespace-normal md:w-full ${
+                        selected.name === m.name
+                          ? 'bg-primary-50 text-primary-700 font-semibold'
+                          : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
+                      }`}
+                    >
+                      <span className="font-mono truncate">{m.name}</span>
+                      {m.alpha && (
+                        <span className="flex-shrink-0 text-[9px] font-bold uppercase tracking-wider text-amber-600 bg-amber-50 border border-amber-200 rounded px-1 py-px">
+                          alpha
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
 
         {/* Right: detail */}
         <div className="flex-1 min-w-0 space-y-5">
           <div className="card">
-            <div className="flex items-center gap-2 mb-3">
+            <div className="flex items-center gap-2 mb-3 flex-wrap">
               <span className="text-lg">{GROUP_ICONS[selected.group]}</span>
               <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{GROUP_LABELS[selected.group]}</span>
               {selected.alpha && (
@@ -78,7 +80,7 @@ export function ClientApiSection() {
                 </span>
               )}
             </div>
-            <h2 className="font-bold text-gray-900 text-lg mb-2 font-mono">{selected.name}</h2>
+            <h2 className="font-bold text-gray-900 text-base sm:text-lg mb-2 font-mono break-all sm:break-normal">{selected.name}</h2>
             <p className="text-sm text-gray-600 mb-4 leading-relaxed">{selected.description}</p>
             <div className="flex items-start gap-2 bg-emerald-50 border border-emerald-100 rounded-xl px-3 py-2 text-xs text-emerald-700 mb-4">
               <span>↩</span>

--- a/demo/src/sections/FactoriesSection.tsx
+++ b/demo/src/sections/FactoriesSection.tsx
@@ -24,41 +24,43 @@ export function FactoriesSection() {
         </p>
       </div>
 
-      <div className="flex gap-6">
+      <div className="flex flex-col md:flex-row gap-4 md:gap-6">
         {/* Left: function list */}
-        <div className="w-56 flex-shrink-0">
-          {Object.entries(groups).map(([groupName, fns]) => (
-            <div key={groupName} className="mb-5">
-              <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2 px-1">{groupName}</p>
-              <div className="space-y-0.5">
-                {fns.map((fn) => (
-                  <button
-                    key={fn.name}
-                    onClick={() => setSelected(fn)}
-                    className={`w-full text-left px-3 py-2 rounded-xl text-xs transition-all flex items-center gap-2 ${
-                      selected.name === fn.name
-                        ? 'bg-primary-50 text-primary-700 font-semibold'
-                        : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
-                    }`}
-                  >
-                    <span className="font-mono truncate">{fn.name}</span>
-                    {fn.alpha && (
-                      <span className="flex-shrink-0 text-[9px] font-bold uppercase tracking-wider text-amber-600 bg-amber-50 border border-amber-200 rounded px-1 py-px">
-                        alpha
-                      </span>
-                    )}
-                  </button>
-                ))}
+        <div className="md:w-56 flex-shrink-0">
+          <div className="flex md:flex-col gap-1 overflow-x-auto md:overflow-x-visible pb-2 md:pb-0">
+            {Object.entries(groups).map(([groupName, fns]) => (
+              <div key={groupName} className="mb-3 md:mb-5 flex-shrink-0">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2 px-1 whitespace-nowrap">{groupName}</p>
+                <div className="flex md:flex-col gap-0.5">
+                  {fns.map((fn) => (
+                    <button
+                      key={fn.name}
+                      onClick={() => setSelected(fn)}
+                      className={`text-left px-3 py-2 rounded-xl text-xs transition-all flex items-center gap-2 whitespace-nowrap md:whitespace-normal md:w-full ${
+                        selected.name === fn.name
+                          ? 'bg-primary-50 text-primary-700 font-semibold'
+                          : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
+                      }`}
+                    >
+                      <span className="font-mono truncate">{fn.name}</span>
+                      {fn.alpha && (
+                        <span className="flex-shrink-0 text-[9px] font-bold uppercase tracking-wider text-amber-600 bg-amber-50 border border-amber-200 rounded px-1 py-px">
+                          alpha
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
 
         {/* Right: detail */}
         <div className="flex-1 min-w-0 space-y-5">
           <div className="card">
             <div className="flex items-center gap-2 mb-4 flex-wrap">
-              <span className="font-mono text-sm text-primary-700 font-bold">{selected.name}</span>
+              <span className="font-mono text-sm text-primary-700 font-bold break-all sm:break-normal">{selected.name}</span>
               <span className="text-gray-300">→</span>
               <span className="text-xs text-amber-700 font-medium bg-amber-50 border border-amber-100 rounded-md px-2 py-0.5">{selected.producesType}</span>
               {selected.alpha && (


### PR DESCRIPTION
## Summary
- Convert fixed sidebar+detail flex layouts to stack vertically on mobile (`flex-col md:flex-row`)
- Rule/method/factory nav lists become horizontally scrollable on small screens, reverting to vertical sidebar at `md` breakpoint
- Fix long monospace method names overflowing on mobile with `break-all`
- Reduce spacing between sections on mobile

## Test plan
- [ ] Open Agent Guide page on mobile viewport (~375px) — rules list should scroll horizontally, detail below
- [ ] Open Client API page on mobile — method groups scroll horizontally, detail card stacks below
- [ ] Open Factory Functions page on mobile — same horizontal scroll + stacked layout
- [ ] Verify all three pages still look correct on desktop (md+ breakpoint) with side-by-side layout

https://claude.ai/code/session_01JvHUjmzMokcXKgAMhuYh5J